### PR TITLE
fix: H2のバウンディングボックスを修正

### DIFF
--- a/src/atoms/H2.ts
+++ b/src/atoms/H2.ts
@@ -24,15 +24,21 @@ export class H2 {
     if (!ctx) {
       throw new Error('Failed to get canvas 2D context');
     }
-    const fontSize = 24 * this.getScale();
-    ctx.font = `${fontSize}px sans-serif`;
-    const txtSize = ctx.measureText(this.getName()).width;
 
+    // "H" のフォントサイズと幅を計算
+    const fontSizeH = 24 * this.getScale();
+    ctx.font = `${fontSizeH}px sans-serif`; // フォントサイズは 24px としておく
+    const hWidth = ctx.measureText('H').width;
+
+    // "2" のフォントサイズと幅を計算
+    const twoWidth = ctx.measureText('2').width;
+
+    // プロパティを設定
     this.x = coordinate.x;
     this.y = coordinate.y;
-    this.w = txtSize;
-    this.h = txtSize;
-    this.r = txtSize / 2;
+    this.w = hWidth + twoWidth;
+    this.h = hWidth;
+    this.r = this.w / 2;
     this.color = this.getColor();
   }
 
@@ -64,11 +70,11 @@ export class H2 {
     // "H" と 下付き "2" を分けて描画する
     const fontSize = 24 * this.getScale();
     ctx.font = `${fontSize}px sans-serif`;
-    ctx.fillText('H', this.x - this.w / 2, this.y);
+    ctx.fillText('H', this.x - this.w / 6, this.y); // 位置は微調整
     // 下付き文字を描画
     const fontSize2 = 18 * this.getScale();
     ctx.font = `${fontSize2}px sans-serif`;
-    ctx.fillText('2', this.x, this.y + 2);
+    ctx.fillText('2', this.x + 12, this.y + 3); // 位置は微調整
   }
 
   public updatePosition(): void {

--- a/src/atoms/H2.ts
+++ b/src/atoms/H2.ts
@@ -61,11 +61,11 @@ export class H2 {
     ctx.shadowOffsetY = 1;
     ctx.shadowBlur = 1;
 
+    // "H" と 下付き "2" を分けて描画する
     const fontSize = 24 * this.getScale();
     ctx.font = `${fontSize}px sans-serif`;
-
-    // "H" と 下付き "2" を分けて描画する
     ctx.fillText('H', this.x - this.w / 2, this.y);
+    // 下付き文字を描画
     const fontSize2 = 18 * this.getScale();
     ctx.font = `${fontSize2}px sans-serif`;
     ctx.fillText('2', this.x, this.y + 2);


### PR DESCRIPTION
- Hと2の描画サイズを考慮しないと駄目だった
- 単純にH2の状態の文字サイズだと大きすぎたので、Hと2それぞれの描画サイズを出したうえで各プロパティに設定するようにした

### fixed

![CleanShot 2025-01-18 at 19 59 12@2x](https://github.com/user-attachments/assets/db38f80c-fd21-4890-b824-2be68b0905c6)

