### PR TITLE
feat: 実ブラウザ計測を自動化するベンチマークツールを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 dist/
 coverage/
 package-lock.json
+bench-reports/

--- a/README.md
+++ b/README.md
@@ -46,6 +46,26 @@ Note: Frame time measurement uses high-precision timestamps (1ms decimal), allow
 |h|30|number|Number of H atoms to generate (scaled by screen width)|
 |o|50|number|Number of O atoms to generate (scaled by screen width)|
 
+### Benchmark Tool
+
+`npm run bench` automates the manual measurement protocol above: it starts Vite, opens a real (headful) Chrome window, measures rAF frame times per scenario, and writes a Markdown report to `bench-reports/`. Pass `--compare <git-ref>` to A/B compare the current working tree against another ref (checked out into a temporary `git worktree`).
+
+Requires Google Chrome and a GUI environment — see [Google Chrome (For Benchmark Tool)](#google-chrome-for-benchmark-tool).
+
+```sh
+npm run bench
+npm run bench -- --compare main
+npm run bench -- --scenarios default,500 --frames 60 --warmup 1000
+```
+
+|option|default|description|
+|:---|:---|:---|
+|`--compare <git-ref>`|(none)|A/B compare against the given ref, measured in the same session|
+|`--scenarios <a,b,c>`|`default,500,1000`|Scenarios to run (choices: `default`, `500`, `1000`, `3000`)|
+|`--frames <N>`|`300` (`60` for the `3000` scenario)|Number of rAF frames to sample per scenario|
+|`--warmup <ms>`|`3000`|Warmup time before sampling starts|
+|`--out <path>`|`bench-reports/report-<YYYYMMDD-HHmmss>.md`|Report output path|
+
 ## TODO
 
 <details><summary>Fixed.</summary>
@@ -143,6 +163,12 @@ sudo dnf install graphviz
 **Windows**
 
 Download the installer from the [official Graphviz download page](https://www.graphviz.org/download/#windows), and follow the setup instructions.
+
+### Google Chrome (For Benchmark Tool)
+
+The benchmark tool (`npm run bench`) launches your locally installed **Google Chrome** via `puppeteer-core` (no Chromium is bundled), so Chrome must be installed.
+
+It runs the browser **headful** on purpose — headless rendering paths differ and can invert benchmark conclusions — so a GUI environment is required (it does not work over SSH or on displayless CI machines).
 
 ## Installation
 

--- a/biome.json
+++ b/biome.json
@@ -6,7 +6,7 @@
     "useIgnoreFile": false
   },
   "files": {
-    "include": ["src/**/*"],
+    "include": ["src/**/*", "scripts/**/*"],
     "ignoreUnknown": false,
     "ignore": []
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "vitest",
     "coverage": "vitest --coverage",
     "depcruise": "npx depcruise src",
-    "dependency-graph": "npx depcruise src --include-only \"^src\" --output-type dot | dot -T svg > dependency-graph.svg"
+    "dependency-graph": "npx depcruise src --include-only \"^src\" --output-type dot | dot -T svg > dependency-graph.svg",
+    "bench": "node scripts/bench/bench.mjs"
   },
   "keywords": [],
   "author": "",
@@ -28,6 +29,7 @@
     "canvas": "^3.0.1",
     "dependency-cruiser": "^16.9.0",
     "jsdom": "^26.0.0",
+    "puppeteer-core": "^23.11.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.7.3",
     "vite": "^6.0.7",

--- a/scripts/bench/args.mjs
+++ b/scripts/bench/args.mjs
@@ -1,0 +1,77 @@
+/** scripts/bench/bench.mjs 用の CLI 引数パーサ。入力配列に対して純粋。 */
+
+const DEFAULT_SCENARIOS = ['default', '500', '1000'];
+const DEFAULT_WARMUP_MS = 3000;
+
+function splitFlag(arg) {
+  const withoutDashes = arg.slice(2);
+  const eqIndex = withoutDashes.indexOf('=');
+  if (eqIndex === -1) return [withoutDashes, undefined];
+  return [withoutDashes.slice(0, eqIndex), withoutDashes.slice(eqIndex + 1)];
+}
+
+function timestamp(date = new Date()) {
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}-${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}`;
+}
+
+export function parseArgs(argv) {
+  const options = {
+    compare: null,
+    scenarios: [...DEFAULT_SCENARIOS],
+    framesOverride: null,
+    warmup: DEFAULT_WARMUP_MS,
+    out: null,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (!arg.startsWith('--')) continue;
+    const [flag, inlineValue] = splitFlag(arg);
+    const takeValue = () =>
+      inlineValue !== undefined ? inlineValue : argv[++i];
+
+    switch (flag) {
+      case 'compare':
+        options.compare = takeValue();
+        break;
+      case 'scenarios':
+        options.scenarios = takeValue()
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean);
+        break;
+      case 'frames':
+        options.framesOverride = Number.parseInt(takeValue(), 10);
+        break;
+      case 'warmup':
+        options.warmup = Number.parseInt(takeValue(), 10);
+        break;
+      case 'out':
+        options.out = takeValue();
+        break;
+      case 'help':
+        options.help = true;
+        break;
+      default:
+        console.warn(`[bench] Unknown option --${flag}`);
+        break;
+    }
+  }
+
+  if (!options.out) {
+    options.out = `bench-reports/report-${timestamp()}.md`;
+  }
+
+  return options;
+}
+
+export const HELP_TEXT = `Usage: npm run bench -- [options]
+
+Options:
+  --compare <git-ref>        指定した git ref を worktree に展開し、現在の作業ツリーと A/B 比較する
+  --scenarios <a,b,c>        計測するシナリオ(既定: default,500,1000。選択肢: default,500,1000,3000)
+  --frames <N>               シナリオごとに収集する rAF フレーム数(既定: 300。3000 シナリオのみ既定 60)
+  --warmup <ms>               計測前のウォームアップ時間 ms(既定: 3000)
+  --out <path>                レポート出力先(既定: bench-reports/report-<YYYYMMDD-HHmmss>.md)
+`;

--- a/scripts/bench/bench.mjs
+++ b/scripts/bench/bench.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+/**
+ * Mizu-ts ベンチマーク CLI。
+ *
+ * これまで再設計・性能改善のたびに手動で行っていた計測プロトコルを自動化する:
+ *   vite 起動 -> Chrome でシナリオ別に rAF 計測 -> Markdown レポート出力
+ * `--compare <git-ref>` を指定すると、その ref を一時的な git worktree に
+ * 展開し、現在の作業ツリーと同一セッション・同一マシン状態で交互に計測して
+ * A/B 比較する。
+ *
+ * 使い方: npm run bench -- [options]
+ *   詳細は args.mjs の HELP_TEXT を参照。
+ */
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { HELP_TEXT, parseArgs } from './args.mjs';
+import { getGitInfo } from './gitInfo.mjs';
+import {
+  launchBrowser,
+  measureScenario,
+  parseOverlayText,
+} from './measure.mjs';
+import { buildReport } from './report.mjs';
+import { buildUrl, defaultFramesFor, resolveScenarios } from './scenarios.mjs';
+import { estimateFps, judgePerformance, mean, median, p95 } from './stats.mjs';
+import { startViteServer, stopViteServer } from './viteServer.mjs';
+import { createCompareWorktree, removeCompareWorktree } from './worktree.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../..');
+
+/** rAF の間隔サンプル + StatsOverlay の生テキストを、レポート用の結果オブジェクトに変換する。 */
+function toScenarioResult(scenario, raw) {
+  const overlay = parseOverlayText(raw.overlayText);
+  const meanMs = mean(raw.deltas);
+  const medianMs = median(raw.deltas);
+  const p95Ms = p95(raw.deltas);
+  return {
+    name: scenario.name,
+    label: scenario.label,
+    meanMs,
+    medianMs,
+    p95Ms,
+    fps: estimateFps(meanMs),
+    updateMs: overlay.updateMs,
+    particleCount: overlay.total,
+    counts: overlay.counts,
+    frames: raw.deltas.length,
+    // (p95 - 中央値) のジッタも渡し、リフレッシュレート律速の可能性を判定する
+    judge: judgePerformance(meanMs, medianMs, p95Ms),
+  };
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    console.log(HELP_TEXT);
+    return;
+  }
+
+  const scenarios = resolveScenarios(options.scenarios);
+
+  // 後片付けタスク(登録順と逆順に実行する)。Ctrl+C(SIGINT)でも
+  // worktree やブラウザ・サーバーが残らないよう、必ずここを通す。
+  //
+  // 注意: SIGINT 経由の cleanup と、main() 自身の finally 経由の cleanup は
+  // 両方とも呼ばれうる(SIGINT 中に browser.close() すると、実行中の
+  // page.evaluate() が reject し、main() 側の finally も走るため)。
+  // 同じ配列に対して独立した while ループを2つ走らせると早取り競争になり、
+  // 一方が「配列が空になった」と早合点して process.exit() してしまい、
+  // もう一方がまだ実行中のタスク(worktree 削除など)を待たずに終了する
+  // 危険がある。そのため cleanup の実行は1つの Promise に集約し、
+  // 呼び出し側が何度呼んでも同じ実行を待つだけにする。
+  const cleanupTasks = [];
+  let cleanupPromise = null;
+  const runCleanup = () => {
+    if (!cleanupPromise) {
+      cleanupPromise = (async () => {
+        while (cleanupTasks.length > 0) {
+          const task = cleanupTasks.pop();
+          try {
+            await task();
+          } catch (err) {
+            console.error('[bench] クリーンアップに失敗しました:', err);
+          }
+        }
+      })();
+    }
+    return cleanupPromise;
+  };
+
+  let sigintReceived = false;
+  const onSigint = async () => {
+    if (sigintReceived) return;
+    sigintReceived = true;
+    console.log('\n[bench] 中断されました。クリーンアップ中...');
+    await runCleanup();
+    process.exit(130);
+  };
+  process.on('SIGINT', onSigint);
+
+  try {
+    console.log('[bench] 現在の作業ツリー用に Vite サーバーを起動します...');
+    const currentServer = await startViteServer(repoRoot);
+    cleanupTasks.push(() => stopViteServer(currentServer.server));
+    const currentGit = getGitInfo(repoRoot);
+    console.log(
+      `[bench] 現在: ${currentGit.branch} @ ${currentGit.commit} (${currentServer.url})`,
+    );
+
+    let compareTarget = null;
+    if (options.compare) {
+      console.log(
+        `[bench] 比較対象 "${options.compare}" 用の worktree を準備します...`,
+      );
+      const worktree = createCompareWorktree(options.compare, repoRoot);
+      cleanupTasks.push(() =>
+        removeCompareWorktree(worktree.path, repoRoot, worktree.cacheDir),
+      );
+
+      const compareServer = await startViteServer(worktree.path, {
+        cacheDir: worktree.cacheDir,
+      });
+      cleanupTasks.push(() => stopViteServer(compareServer.server));
+
+      const compareGit = getGitInfo(worktree.path);
+      console.log(
+        `[bench] 比較対象: ${compareGit.branch} @ ${compareGit.commit} (${compareServer.url})`,
+      );
+      compareTarget = {
+        server: compareServer,
+        git: compareGit,
+        ref: options.compare,
+      };
+    }
+
+    console.log('[bench] Chrome を起動します(ウィンドウが開くのは正常です)...');
+    const browser = await launchBrowser();
+    cleanupTasks.push(() => browser.close());
+    const chromeVersion = await browser.version();
+
+    const results = { current: [], compare: [] };
+
+    for (const scenario of scenarios) {
+      const frames = options.framesOverride ?? defaultFramesFor(scenario.name);
+      console.log(
+        `[bench] シナリオ "${scenario.name}"(frames=${frames}, warmup=${options.warmup}ms)`,
+      );
+
+      console.log('  現在の作業ツリーを計測中...');
+      const currentUrl = buildUrl(currentServer.url, scenario);
+      const currentRaw = await measureScenario(browser, currentUrl, {
+        warmupMs: options.warmup,
+        frames,
+      });
+      results.current.push(toScenarioResult(scenario, currentRaw));
+
+      if (compareTarget) {
+        console.log(`  比較対象(${options.compare})を計測中...`);
+        const compareUrl = buildUrl(compareTarget.server.url, scenario);
+        const compareRaw = await measureScenario(browser, compareUrl, {
+          warmupMs: options.warmup,
+          frames,
+        });
+        results.compare.push(toScenarioResult(scenario, compareRaw));
+      }
+    }
+
+    const report = buildReport({
+      generatedAt: new Date(),
+      current: { git: currentGit },
+      compare: compareTarget
+        ? { git: compareTarget.git, ref: options.compare }
+        : null,
+      chromeVersion,
+      viewport: { width: 1280, height: 800 },
+      protocol: { warmupMs: options.warmup },
+      results,
+    });
+
+    const outPath = path.isAbsolute(options.out)
+      ? options.out
+      : path.join(repoRoot, options.out);
+    mkdirSync(path.dirname(outPath), { recursive: true });
+    writeFileSync(outPath, `${report.markdown}\n`, 'utf8');
+
+    console.log(`\n${report.consoleSummary}`);
+    console.log(`\n[bench] レポートを書き出しました: ${outPath}`);
+  } finally {
+    process.off('SIGINT', onSigint);
+    await runCleanup();
+  }
+}
+
+main().catch((err) => {
+  console.error('[bench] 失敗しました:', err);
+  process.exitCode = 1;
+});

--- a/scripts/bench/gitInfo.mjs
+++ b/scripts/bench/gitInfo.mjs
@@ -1,0 +1,14 @@
+import { execFileSync } from 'node:child_process';
+
+/** 指定した cwd(リポジトリ or worktree)のブランチ名と短縮コミットハッシュを取得する。 */
+export function getGitInfo(cwd) {
+  const branch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+    cwd,
+  })
+    .toString()
+    .trim();
+  const commit = execFileSync('git', ['rev-parse', '--short', 'HEAD'], { cwd })
+    .toString()
+    .trim();
+  return { branch, commit };
+}

--- a/scripts/bench/measure.mjs
+++ b/scripts/bench/measure.mjs
@@ -1,0 +1,132 @@
+import puppeteer from 'puppeteer-core';
+
+const VIEWPORT = { width: 1280, height: 800 };
+
+/**
+ * インストール済みの Chrome('chrome' channel)をヘッドフルで起動する。
+ * ヘッドレスはあえて使わない: ヘッドレス Chrome や jsdom はラスタライズ
+ * 経路が実ブラウザと異なり、過去の描画最適化の検証では、ヘッドレス相当の
+ * マイクロベンチが実ページの rAF 計測と**逆の結論**(最適化のつもりが
+ * 実際は退行)を出した事例がある。ベンチ計測は必ず実際に画面表示される
+ * ブラウザウィンドウで行う。
+ */
+export async function launchBrowser() {
+  return puppeteer
+    .launch({
+      channel: 'chrome',
+      headless: false,
+      defaultViewport: VIEWPORT,
+      args: [
+        `--window-size=${VIEWPORT.width},${VIEWPORT.height}`,
+        '--window-position=0,0',
+      ],
+      // puppeteer は既定で SIGINT/SIGTERM/SIGHUP を自前でハンドリングしてブラウザを
+      // 閉じようとする。bench.mjs 側にも Ctrl+C 用の後片付けハンドラ(vite サーバー・
+      // worktree も含めて片付ける)があり、両方が同時にブラウザを閉じようとすると
+      // 競合して browser.close() が正しく解決しなくなることがある。シグナル処理は
+      // bench.mjs 側に一本化する。
+      handleSIGINT: false,
+      handleSIGTERM: false,
+      handleSIGHUP: false,
+    })
+    .catch((err) => {
+      // Chrome が見つからない場合、puppeteer-core の生エラーは分かりにくいため
+      // 前提条件を日本語で案内する
+      throw new Error(
+        [
+          'Chrome の起動に失敗しました。以下を確認してください:',
+          '  1. Google Chrome がインストールされていること',
+          '     (このツールは Chromium を同梱せず、インストール済みの Chrome を使います)',
+          '  2. GUI 環境で実行していること',
+          '     (計測精度のためヘッドフル起動が必須。SSH 先やディスプレイのない環境では動きません)',
+          `元のエラー: ${err.message}`,
+        ].join('\n'),
+      );
+    });
+}
+
+/**
+ * `url` を開き `warmupMs` だけ待機した後、requestAnimationFrame の間隔を
+ * `frames` 回分(ms)収集し、最終フレームの StatsOverlay 表示テキストも
+ * あわせて取得する。
+ *
+ * タイムアウトは無効化(0 = 無制限)している。重いシナリオ(h=3000 等)は
+ * 1フレームが数秒かかることもあるため、完走できるようにするため。
+ */
+export async function measureScenario(browser, url, { warmupMs, frames }) {
+  const page = await browser.newPage();
+  page.setDefaultTimeout(0);
+  page.setDefaultNavigationTimeout(0);
+
+  try {
+    await page.goto(url, { waitUntil: 'load' });
+    await new Promise((resolve) => setTimeout(resolve, warmupMs));
+
+    const result = await page.evaluate((frameCount) => {
+      return new Promise((resolve) => {
+        const deltas = [];
+        let last = null;
+
+        function step(ts) {
+          if (last !== null) {
+            deltas.push(ts - last);
+          }
+          last = ts;
+          if (deltas.length >= frameCount) {
+            // StatsOverlay(src/debug/StatsOverlay.ts)は body 直下に div を
+            // 追加するだけだが、開発サーバーの他のツール(例:
+            // vite-plugin-checker の診断オーバーレイ)も同様に body 直下へ
+            // div を挿入することがあるため、位置ではなく中身
+            // (先頭が "FPS:" で始まる)で特定する。
+            const overlay = Array.from(
+              document.querySelectorAll('body > div'),
+            ).find((el) => el.innerText.trimStart().startsWith('FPS:'));
+            resolve({ deltas, overlayText: overlay ? overlay.innerText : '' });
+          } else {
+            requestAnimationFrame(step);
+          }
+        }
+        requestAnimationFrame(step);
+      });
+    }, frames);
+
+    return result;
+  } finally {
+    await page.close();
+  }
+}
+
+/**
+ * StatsOverlay(src/debug/StatsOverlay.ts)が描画したテキストを構造化データに
+ * パースする: `Update: Nms` -> updateMs、`Total: N` -> total、それ以外の
+ * "Kind: N" 行 -> counts[Kind]。
+ */
+export function parseOverlayText(text) {
+  const stats = { updateMs: null, total: null, counts: {} };
+  const lines = text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  for (const line of lines) {
+    const separatorIndex = line.indexOf(':');
+    if (separatorIndex === -1) continue;
+    const key = line.slice(0, separatorIndex).trim();
+    const rawValue = line.slice(separatorIndex + 1).trim();
+    const value = Number.parseFloat(rawValue);
+    if (Number.isNaN(value)) continue;
+
+    if (key === 'Update') {
+      stats.updateMs = value;
+    } else if (key === 'Total') {
+      stats.total = value;
+    } else if (key === 'FPS' || key === 'Frame') {
+      // FPS/フレーム間隔は自前の rAF サンプルから算出し直すため、
+      // 二重管理を避ける目的でオーバーレイ側の値は使わない。
+    } else {
+      stats.counts[key] = value;
+    }
+  }
+
+  return stats;
+}

--- a/scripts/bench/report.mjs
+++ b/scripts/bench/report.mjs
@@ -1,0 +1,133 @@
+import os from 'node:os';
+import {
+  buildComparisonTable,
+  buildDetailTable,
+  buildSummaryTable,
+  judgeRatio,
+} from './stats.mjs';
+
+const READING_GUIDE = `## レポートの読み方
+
+- **フレーム時間の一定値への張り付き**: ディスプレイのリフレッシュレート(60Hz なら 16.7ms、75Hz なら 13.3ms など)の上限で頭打ちになっている状態です。それ以上は速くなりません。
+- **Frame と Update の乖離**: \`Frame\`(rAF 間隔)が \`Update\`(renderFrame の実行時間)より大きい場合、その差分は JS 以外(ラスタライズ・GC 等)のコストです。
+- **粒子数列も見ること**: H2o の滞留数がフレーム時間を支配するため、詳細表の終了時粒子数は毎回確認してください。
+- **絶対値の比較は不可**: 環境ノイズがあるため、別日に計測した絶対値同士を比較しないでください。比較する場合は必ず \`--compare\` で同一セッション・同一マシン状態で計測してください。`;
+
+function formatDate(date) {
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+}
+
+function formatOs() {
+  return `${os.type()} ${os.release()} (${os.arch()})`;
+}
+
+/**
+ * Markdown レポート全文と、コンソール向けの短いサマリを組み立てる。
+ *
+ * `results.current` / `results.compare` はシナリオ結果オブジェクトの配列
+ * (シナリオごとに同じ順序)。各要素の形は次のとおり:
+ *   { name, label, meanMs, medianMs, p95Ms, fps, updateMs, particleCount,
+ *     frames, judge }
+ */
+export function buildReport({
+  generatedAt,
+  current,
+  compare,
+  chromeVersion,
+  viewport,
+  protocol,
+  results,
+}) {
+  const lines = [];
+
+  lines.push('# Mizu-ts ベンチマークレポート');
+  lines.push('');
+  lines.push(`- 実行日時: ${formatDate(generatedAt)}`);
+  lines.push(`- 現在: \`${current.git.branch}\` @ \`${current.git.commit}\``);
+  if (compare) {
+    lines.push(
+      `- 比較対象: \`${compare.ref}\`(\`${compare.git.branch}\` @ \`${compare.git.commit}\`)`,
+    );
+  }
+  lines.push(`- OS: ${formatOs()}`);
+  lines.push(`- Chrome: ${chromeVersion}`);
+  lines.push(`- ビューポート: ${viewport.width}x${viewport.height}`);
+  lines.push(`- プロトコル: warmup ${protocol.warmupMs}ms`);
+  lines.push('');
+
+  lines.push('## 結果サマリ');
+  lines.push('');
+  const summaryEntries = results.current.map((r) => ({
+    scenarioLabel: r.label,
+    meanMs: r.meanMs,
+    fps: r.fps,
+    judge: r.judge,
+  }));
+  const summaryTable = buildSummaryTable(summaryEntries);
+  lines.push(summaryTable);
+  lines.push('');
+
+  if (compare) {
+    lines.push('## 比較(--compare)');
+    lines.push('');
+    const comparisonEntries = results.current.map((cur, i) => {
+      const cmp = results.compare[i];
+      // 双方がディスプレイ同期律速の場合、フレーム時間はリフレッシュレートの
+      // 上限に張り付いているだけで倍率に意味がないため「比較不能」にする
+      const bothVsyncBound = Boolean(
+        cur.judge?.vsyncBound && cmp.judge?.vsyncBound,
+      );
+      return {
+        scenarioLabel: cur.label,
+        compareMs: cmp.meanMs,
+        currentMs: cur.meanMs,
+        ratio: judgeRatio(cmp.meanMs, cur.meanMs, { bothVsyncBound }),
+      };
+    });
+    lines.push(buildComparisonTable(comparisonEntries));
+    lines.push('');
+  }
+
+  lines.push('## 詳細');
+  lines.push('');
+  lines.push(
+    buildDetailTable(
+      results.current.map((r) => ({
+        scenarioLabel: r.label,
+        medianMs: r.medianMs,
+        p95Ms: r.p95Ms,
+        updateMs: r.updateMs,
+        particleCount: r.particleCount,
+        frames: r.frames,
+      })),
+    ),
+  );
+  lines.push('');
+
+  if (compare) {
+    lines.push('### 詳細(比較対象)');
+    lines.push('');
+    lines.push(
+      buildDetailTable(
+        results.compare.map((r) => ({
+          scenarioLabel: r.label,
+          medianMs: r.medianMs,
+          p95Ms: r.p95Ms,
+          updateMs: r.updateMs,
+          particleCount: r.particleCount,
+          frames: r.frames,
+        })),
+      ),
+    );
+    lines.push('');
+  }
+
+  lines.push(READING_GUIDE);
+  lines.push('');
+
+  const markdown = lines.join('\n');
+  const consoleSummary = ['結果サマリ:', summaryTable].join('\n');
+
+  return { markdown, consoleSummary };
+}

--- a/scripts/bench/scenarios.mjs
+++ b/scripts/bench/scenarios.mjs
@@ -1,0 +1,41 @@
+/**
+ * ベンチツールのシナリオ定義。
+ *
+ * これまで性能検証で手動実施していた計測プロトコル(1280x800 の
+ * ビューポートで ?m=1&h=&o= を開き、ウォームアップ後に rAF 差分を採取)を
+ * 再現する: 「default」シナリオは main.ts 自身の既定値
+ * (h=30, o=50。シミュレータ側でスケールされる)に依存し、負荷シナリオは
+ * 明示的な ?h=&o= 値を渡す。
+ */
+
+export const SCENARIO_ORDER = ['default', '500', '1000', '3000'];
+
+export const SCENARIO_DEFS = {
+  default: { h: 30, o: 50, label: 'デフォルト (h=30, o=50)' },
+  500: { h: 500, o: 500, label: 'h=500, o=500' },
+  1000: { h: 1000, o: 1000, label: 'h=1000, o=1000' },
+  3000: { h: 3000, o: 3000, label: 'h=3000, o=3000' },
+};
+
+/** 3000 シナリオのみ既定フレーム数を 60 にする(他は 300)。 */
+export function defaultFramesFor(scenarioName) {
+  return scenarioName === '3000' ? 60 : 300;
+}
+
+/** シナリオ名の配列 -> シナリオ定義オブジェクトの配列。未知の名前は例外。 */
+export function resolveScenarios(names) {
+  return names.map((name) => {
+    const def = SCENARIO_DEFS[name];
+    if (!def) {
+      throw new Error(
+        `Unknown scenario "${name}". Available: ${SCENARIO_ORDER.join(', ')}`,
+      );
+    }
+    return { name, ...def };
+  });
+}
+
+/** ベース URL + シナリオ定義 -> 計測対象 URL(?m=1&h=&o=)。 */
+export function buildUrl(baseUrl, scenario) {
+  return `${baseUrl}/?m=1&h=${scenario.h}&o=${scenario.o}`;
+}

--- a/scripts/bench/stats.mjs
+++ b/scripts/bench/stats.mjs
@@ -1,0 +1,186 @@
+/**
+ * ベンチツール用の純粋な統計・整形関数群。
+ *
+ * このモジュールの関数はすべて純粋関数(I/O・ブラウザ操作・プロセスアクセスなし)。
+ * そのため vitest で直接ユニットテストできる(tests/bench/stats.test.ts 参照)。
+ */
+
+/** 算術平均。空配列の場合は 0 を返す。 */
+export function mean(values) {
+  if (values.length === 0) return 0;
+  return values.reduce((sum, v) => sum + v, 0) / values.length;
+}
+
+/** 中央値。空配列の場合は 0 を返す。 */
+export function median(values) {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+}
+
+/**
+ * nearest-rank 法によるパーセンタイル計算(単純で決定的)。
+ * `p` は 0〜100。空配列の場合は 0 を返す。
+ */
+export function percentile(values, p) {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil((p / 100) * sorted.length) - 1),
+  );
+  return sorted[index];
+}
+
+/** p95 のショートハンド。 */
+export function p95(values) {
+  return percentile(values, 95);
+}
+
+/** 平均フレーム時間(ms)から概算 FPS を求める。 */
+export function estimateFps(meanMs) {
+  return meanMs > 0 ? 1000 / meanMs : 0;
+}
+
+/** リフレッシュレート律速とみなす (p95 - 中央値) ジッタ上限(ms)。 */
+const REFRESH_BOUND_JITTER_MS = 2;
+
+/**
+ * フレーム時間の統計からシナリオの性能を判定する。
+ * - 平均 17.5ms 以下: 「60fps維持」(✅)。さらに (p95 - 中央値) が
+ *   REFRESH_BOUND_JITTER_MS 未満(= フレーム時間が一定値に張り付いている)なら
+ *   ディスプレイのリフレッシュレートに律速されている可能性が高いため、
+ *   「表示リフレッシュレート律速の可能性」の注記と vsyncBound フラグを付ける。
+ *   60Hz(16.7ms)前提の閾値判定はしない(75Hz なら 13.3ms 等で張り付くため)。
+ * - 平均 33.4ms 以下: 「30〜60fps」(⚠️)
+ * - それ以外: 「30fps未満」(❌)
+ *
+ * medianMs / p95Ms を省略した場合はジッタ 0 とみなす(張り付き扱い)。
+ */
+export function judgePerformance(meanMs, medianMs = meanMs, p95Ms = meanMs) {
+  if (meanMs <= 17.5) {
+    const vsyncBound = p95Ms - medianMs < REFRESH_BOUND_JITTER_MS;
+    return {
+      emoji: '✅',
+      label: vsyncBound
+        ? '60fps維持(表示リフレッシュレート律速の可能性)'
+        : '60fps維持',
+      vsyncBound,
+    };
+  }
+  if (meanMs <= 33.4) {
+    return { emoji: '⚠️', label: '30〜60fps', vsyncBound: false };
+  }
+  return { emoji: '❌', label: '30fps未満', vsyncBound: false };
+}
+
+/** 「≒同等」とみなす差分の上限(±%)。 */
+const EQUIVALENCE_BAND_PCT = 5;
+
+/**
+ * 比較対象(--compare ref)の平均フレーム時間と現在の平均フレーム時間を比べ、
+ * 人が読みやすい倍率ラベルを生成する。
+ *
+ * - bothVsyncBound が true(両者ともディスプレイ同期律速と判定)の場合、
+ *   フレーム時間はどちらもリフレッシュレートの上限に張り付いているだけで
+ *   倍率に意味がないため「➖ 比較不能」を返す。
+ * - 差が ±5% 以内なら「➖ ≒同等(符号付き差分%)」。差分% は
+ *   (currentMs - compareMs) / compareMs で、正 = 現在の方が遅い。
+ * - ±5% を超えた場合のみ ratio = compareMs / currentMs で
+ *   ratio >= 1 -> ✅ "Nx faster" / ratio < 1 -> ❌ "Nx slower"
+ */
+export function judgeRatio(
+  compareMs,
+  currentMs,
+  { bothVsyncBound = false } = {},
+) {
+  if (currentMs <= 0 || compareMs <= 0) {
+    return { ratio: 0, emoji: '❌', label: 'N/A' };
+  }
+  if (bothVsyncBound) {
+    return {
+      ratio: null,
+      emoji: '➖',
+      label: '比較不能(双方ディスプレイ同期律速)',
+    };
+  }
+  const diffPct = ((currentMs - compareMs) / compareMs) * 100;
+  const ratio = compareMs / currentMs;
+  if (Math.abs(diffPct) <= EQUIVALENCE_BAND_PCT) {
+    const sign = diffPct >= 0 ? '+' : '';
+    return {
+      ratio,
+      emoji: '➖',
+      label: `≒同等(${sign}${diffPct.toFixed(1)}%)`,
+    };
+  }
+  if (ratio >= 1) {
+    return { ratio, emoji: '✅', label: `${ratio.toFixed(1)}x faster` };
+  }
+  return { ratio, emoji: '❌', label: `${(1 / ratio).toFixed(1)}x slower` };
+}
+
+/** ヘッダ配列と行セル配列から GitHub Flavored Markdown のテーブルを生成する。 */
+export function renderMarkdownTable(headers, rows) {
+  const headerLine = `| ${headers.join(' | ')} |`;
+  const separatorLine = `| ${headers.map(() => '---').join(' | ')} |`;
+  const bodyLines = rows.map((row) => `| ${row.join(' | ')} |`);
+  return [headerLine, separatorLine, ...bodyLines].join('\n');
+}
+
+/**
+ * 「結果サマリ」表を生成する。
+ * entries: [{ scenarioLabel, meanMs, fps, judge: { emoji, label } }]
+ */
+export function buildSummaryTable(entries) {
+  const headers = ['シナリオ', '平均 (ms)', 'FPS', '判定'];
+  const rows = entries.map((e) => [
+    e.scenarioLabel,
+    e.meanMs.toFixed(2),
+    e.fps.toFixed(1),
+    `${e.judge.emoji} ${e.judge.label}`,
+  ]);
+  return renderMarkdownTable(headers, rows);
+}
+
+/**
+ * 「--compare」比較表を生成する。
+ * entries: [{ scenarioLabel, compareMs, currentMs, ratio: { emoji, label } }]
+ */
+export function buildComparisonTable(entries) {
+  const headers = ['シナリオ', '比較対象 (ms)', '現在 (ms)', '倍率'];
+  const rows = entries.map((e) => [
+    e.scenarioLabel,
+    e.compareMs.toFixed(2),
+    e.currentMs.toFixed(2),
+    `${e.ratio.emoji} ${e.ratio.label}`,
+  ]);
+  return renderMarkdownTable(headers, rows);
+}
+
+/**
+ * 詳細表を生成する。
+ * entries: [{ scenarioLabel, medianMs, p95Ms, updateMs, particleCount, frames }]
+ */
+export function buildDetailTable(entries) {
+  const headers = [
+    'シナリオ',
+    '中央値 (ms)',
+    'p95 (ms)',
+    'Update (ms)',
+    '終了時粒子数',
+    '計測フレーム数',
+  ];
+  const rows = entries.map((e) => [
+    e.scenarioLabel,
+    e.medianMs.toFixed(2),
+    e.p95Ms.toFixed(2),
+    e.updateMs != null ? e.updateMs.toFixed(2) : 'N/A',
+    e.particleCount != null ? String(e.particleCount) : 'N/A',
+    String(e.frames),
+  ]);
+  return renderMarkdownTable(headers, rows);
+}

--- a/scripts/bench/viteServer.mjs
+++ b/scripts/bench/viteServer.mjs
@@ -1,0 +1,46 @@
+import { createServer } from 'vite';
+
+/**
+ * `root` を起点に Vite の開発サーバーを(JS API で)起動する。ポートは
+ * OS 割り当て(port: 0)にすることで、複数サーバー(現在の作業ツリー +
+ * --compare の worktree)を衝突なく同時起動できるようにする。
+ *
+ * `cacheDir` を指定した場合、その場所を Vite の依存最適化キャッシュ
+ * (既定では `node_modules/.vite`)として使う。--compare の worktree は
+ * メインリポジトリの node_modules をシンボリックリンクして共有するため、
+ * キャッシュディレクトリも既定のままだと物理的に同じ場所を指してしまう。
+ * 2つの Vite サーバー間でキャッシュの取り合いにならないよう、worktree 側
+ * には隔離された一時ディレクトリを渡す。
+ *
+ * `resolve.preserveSymlinks: true` も必須: これがないと、シンボリック
+ * リンクされた node_modules 経由で解決されるファイルの実パスと
+ * Vite の内部モジュールグラフ上のパスが食い違い、TypeScript の変換
+ * (型注釈の除去)が行われないまま生の .ts ソースがそのまま配信されてしまう
+ * (ブラウザ側で `Unexpected token ':'` の SyntaxError になる)。
+ */
+export async function startViteServer(root, { cacheDir } = {}) {
+  const server = await createServer({
+    root,
+    cacheDir,
+    resolve: { preserveSymlinks: true },
+    server: { port: 0, strictPort: false, host: '127.0.0.1' },
+    logLevel: 'error',
+  });
+  await server.listen();
+
+  const address = server.httpServer?.address();
+  const port = typeof address === 'object' && address ? address.port : null;
+  if (!port) {
+    throw new Error(
+      `Failed to determine the Vite server port for root: ${root}`,
+    );
+  }
+
+  return { server, url: `http://127.0.0.1:${port}`, root };
+}
+
+export async function stopViteServer(server) {
+  if (server) {
+    await server.close();
+  }
+}

--- a/scripts/bench/worktree.mjs
+++ b/scripts/bench/worktree.mjs
@@ -1,0 +1,76 @@
+import { execFileSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
+import { existsSync, rmSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+/**
+ * `ref` を新規の一時 `git worktree` にチェックアウトし、メインリポジトリの
+ * node_modules をシンボリックリンクする(worktree 側の vite.config.js や
+ * devDependencies の解決先が必要になるが、古い ref を動かすためだけに
+ * 二重に `npm install` するのは避けたい)。
+ */
+export function createCompareWorktree(ref, repoRoot) {
+  const uniqueSuffix = `${Date.now()}-${randomBytes(4).toString('hex')}`;
+  const worktreePath = path.join(tmpdir(), `mizu-ts-bench-${uniqueSuffix}`);
+
+  execFileSync('git', ['worktree', 'add', '--detach', worktreePath, ref], {
+    cwd: repoRoot,
+    stdio: 'pipe',
+  });
+
+  const nodeModulesTarget = path.join(repoRoot, 'node_modules');
+  const nodeModulesLink = path.join(worktreePath, 'node_modules');
+  if (existsSync(nodeModulesTarget)) {
+    symlinkSync(nodeModulesTarget, nodeModulesLink, 'dir');
+  }
+
+  // node_modules をシンボリックリンクで共有しているため、Vite の依存最適化
+  // キャッシュ(node_modules/.vite)は本体側と物理的に同じ場所になってしまう。
+  // 本体の Vite サーバーと同時に動かすとキャッシュ破損の原因になるため、
+  // worktree 専用の隔離されたキャッシュディレクトリを別途用意する。
+  const cacheDir = path.join(
+    tmpdir(),
+    `mizu-ts-bench-vite-cache-${uniqueSuffix}`,
+  );
+
+  return { path: worktreePath, ref, cacheDir };
+}
+
+/**
+ * createCompareWorktree で作成した worktree(と、その専用 Vite キャッシュ
+ * ディレクトリ)を削除する。一部失敗しても続行する。
+ */
+export function removeCompareWorktree(worktreePath, repoRoot, cacheDir) {
+  try {
+    execFileSync('git', ['worktree', 'remove', worktreePath, '--force'], {
+      cwd: repoRoot,
+      stdio: 'pipe',
+    });
+  } catch (err) {
+    console.warn(
+      `[bench] git worktree remove に失敗したため手動クリーンアップにフォールバックします: ${err.message}`,
+    );
+    try {
+      rmSync(worktreePath, { recursive: true, force: true });
+    } catch {
+      // ベストエフォート(失敗しても無視)
+    }
+    try {
+      execFileSync('git', ['worktree', 'prune'], {
+        cwd: repoRoot,
+        stdio: 'pipe',
+      });
+    } catch {
+      // ベストエフォート(失敗しても無視)
+    }
+  }
+
+  if (cacheDir) {
+    try {
+      rmSync(cacheDir, { recursive: true, force: true });
+    } catch {
+      // ベストエフォート(失敗しても無視)
+    }
+  }
+}

--- a/tests/bench/stats.test.ts
+++ b/tests/bench/stats.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildComparisonTable,
+  buildDetailTable,
+  buildSummaryTable,
+  estimateFps,
+  judgePerformance,
+  judgeRatio,
+  mean,
+  median,
+  p95,
+  percentile,
+  renderMarkdownTable,
+} from '../../scripts/bench/stats.mjs';
+
+describe('mean', () => {
+  it('空配列は 0', () => {
+    expect(mean([])).toBe(0);
+  });
+
+  it('平均値を計算する', () => {
+    expect(mean([1, 2, 3])).toBe(2);
+    expect(mean([10])).toBe(10);
+  });
+});
+
+describe('median', () => {
+  it('空配列は 0', () => {
+    expect(median([])).toBe(0);
+  });
+
+  it('奇数個は中央の値', () => {
+    expect(median([3, 1, 2])).toBe(2);
+  });
+
+  it('偶数個は中央2値の平均', () => {
+    expect(median([1, 2, 3, 4])).toBe(2.5);
+  });
+
+  it('元の配列を破壊しない', () => {
+    const values = [3, 1, 2];
+    median(values);
+    expect(values).toEqual([3, 1, 2]);
+  });
+});
+
+describe('percentile / p95', () => {
+  it('空配列は 0', () => {
+    expect(percentile([], 95)).toBe(0);
+    expect(p95([])).toBe(0);
+  });
+
+  it('p95 は nearest-rank 法で上位に近い値を返す', () => {
+    const values = Array.from({ length: 100 }, (_, i) => i + 1); // 1..100
+    expect(p95(values)).toBe(95);
+  });
+
+  it('要素数が少なくても範囲外にならない', () => {
+    expect(percentile([5], 95)).toBe(5);
+    expect(percentile([1, 2], 50)).toBe(1);
+  });
+});
+
+describe('estimateFps', () => {
+  it('16.67ms でおよそ 60fps', () => {
+    expect(estimateFps(16.666)).toBeCloseTo(60, 0);
+  });
+
+  it('0 以下の場合は 0', () => {
+    expect(estimateFps(0)).toBe(0);
+    expect(estimateFps(-1)).toBe(0);
+  });
+});
+
+describe('judgePerformance', () => {
+  it('60Hz で張り付き(16.7ms・低ジッタ)はリフレッシュレート律速の注記付き', () => {
+    const result = judgePerformance(16.7, 16.7, 17.5); // p95 - 中央値 = 0.8ms < 2ms
+    expect(result.emoji).toBe('✅');
+    expect(result.label).toBe('60fps維持(表示リフレッシュレート律速の可能性)');
+    expect(result.vsyncBound).toBe(true);
+  });
+
+  it('75Hz で張り付き(13.3ms・低ジッタ)も律速と判定される(60Hz 前提にしない)', () => {
+    const result = judgePerformance(13.34, 13.3, 14.3); // p95 - 中央値 = 1.0ms < 2ms
+    expect(result.emoji).toBe('✅');
+    expect(result.label).toContain('表示リフレッシュレート律速の可能性');
+    expect(result.vsyncBound).toBe(true);
+  });
+
+  it('平均が速くてもジッタが大きい(p95 - 中央値 >= 2ms)場合は張り付きとみなさない', () => {
+    const result = judgePerformance(10, 9, 15); // p95 - 中央値 = 6ms
+    expect(result.emoji).toBe('✅');
+    expect(result.label).toBe('60fps維持');
+    expect(result.vsyncBound).toBe(false);
+  });
+
+  it('ジッタがちょうど 2ms は張り付きとみなさない(境界)', () => {
+    const result = judgePerformance(13, 13, 15); // p95 - 中央値 = 2.0ms
+    expect(result.vsyncBound).toBe(false);
+    expect(result.label).toBe('60fps維持');
+  });
+
+  it('30〜60fps 相当は warning', () => {
+    const result = judgePerformance(25, 25, 26);
+    expect(result.emoji).toBe('⚠️');
+    expect(result.vsyncBound).toBe(false);
+  });
+
+  it('30fps 未満は NG', () => {
+    const result = judgePerformance(100, 100, 110);
+    expect(result.emoji).toBe('❌');
+    expect(result.vsyncBound).toBe(false);
+  });
+});
+
+describe('judgeRatio', () => {
+  it('現在の方が速い場合は faster 表記', () => {
+    const result = judgeRatio(300, 100); // compare=300ms, current=100ms -> 3x faster
+    expect(result.emoji).toBe('✅');
+    expect(result.label).toBe('3.0x faster');
+  });
+
+  it('現在の方が遅い場合は slower 表記', () => {
+    const result = judgeRatio(100, 200); // current is 2x slower
+    expect(result.emoji).toBe('❌');
+    expect(result.label).toBe('2.0x slower');
+  });
+
+  it('同値は ➖ ≒同等(+0.0%)', () => {
+    const result = judgeRatio(13.34, 13.34);
+    expect(result.emoji).toBe('➖');
+    expect(result.label).toBe('≒同等(+0.0%)');
+  });
+
+  it('差が +5% ちょうどは ≒同等(境界は同等帯に含む)', () => {
+    const result = judgeRatio(100, 105); // current が 5% 遅い
+    expect(result.emoji).toBe('➖');
+    expect(result.label).toBe('≒同等(+5.0%)');
+  });
+
+  it('差が -5% ちょうども ≒同等(符号付きで表示)', () => {
+    const result = judgeRatio(100, 95); // current が 5% 速い
+    expect(result.emoji).toBe('➖');
+    expect(result.label).toBe('≒同等(-5.0%)');
+  });
+
+  it('差が +5% を超えたら slower 表記(境界のすぐ外)', () => {
+    const result = judgeRatio(100, 105.2); // +5.2%
+    expect(result.emoji).toBe('❌');
+    expect(result.label).toContain('slower');
+  });
+
+  it('差が -5% を超えたら faster 表記(境界のすぐ外)', () => {
+    const result = judgeRatio(100, 94.8); // -5.2%
+    expect(result.emoji).toBe('✅');
+    expect(result.label).toContain('faster');
+  });
+
+  it('双方ディスプレイ同期律速なら ➖ 比較不能', () => {
+    const result = judgeRatio(13.34, 13.34, { bothVsyncBound: true });
+    expect(result.emoji).toBe('➖');
+    expect(result.label).toBe('比較不能(双方ディスプレイ同期律速)');
+    expect(result.ratio).toBeNull();
+  });
+
+  it('bothVsyncBound でも 0 以下の値は N/A が優先', () => {
+    expect(judgeRatio(0, 100, { bothVsyncBound: true }).label).toBe('N/A');
+  });
+
+  it('0 以下の値は N/A', () => {
+    expect(judgeRatio(0, 100).label).toBe('N/A');
+    expect(judgeRatio(100, 0).label).toBe('N/A');
+  });
+});
+
+describe('renderMarkdownTable', () => {
+  it('ヘッダ・セパレータ・行を持つ Markdown テーブルを生成する', () => {
+    const table = renderMarkdownTable(['A', 'B'], [['1', '2']]);
+    expect(table).toBe('| A | B |\n| --- | --- |\n| 1 | 2 |');
+  });
+});
+
+describe('buildSummaryTable', () => {
+  it('サマリ表を生成する', () => {
+    const table = buildSummaryTable([
+      { scenarioLabel: 'default', meanMs: 16.67, fps: 60, judge: { emoji: '✅', label: '60fps維持' } },
+    ]);
+    expect(table).toContain('| シナリオ | 平均 (ms) | FPS | 判定 |');
+    expect(table).toContain('| default | 16.67 | 60.0 | ✅ 60fps維持 |');
+  });
+});
+
+describe('buildComparisonTable', () => {
+  it('比較表を生成する', () => {
+    const table = buildComparisonTable([
+      {
+        scenarioLabel: '500',
+        compareMs: 250,
+        currentMs: 100,
+        ratio: { emoji: '✅', label: '2.5x faster' },
+      },
+    ]);
+    expect(table).toContain('| シナリオ | 比較対象 (ms) | 現在 (ms) | 倍率 |');
+    expect(table).toContain('| 500 | 250.00 | 100.00 | ✅ 2.5x faster |');
+  });
+});
+
+describe('buildDetailTable', () => {
+  it('詳細表を生成する', () => {
+    const table = buildDetailTable([
+      {
+        scenarioLabel: 'default',
+        medianMs: 16.7,
+        p95Ms: 17.5,
+        updateMs: 1.3,
+        particleCount: 200,
+        frames: 300,
+      },
+    ]);
+    expect(table).toContain('| シナリオ | 中央値 (ms) | p95 (ms) | Update (ms) | 終了時粒子数 | 計測フレーム数 |');
+    expect(table).toContain('| default | 16.70 | 17.50 | 1.30 | 200 | 300 |');
+  });
+
+  it('updateMs / particleCount が null の場合は N/A', () => {
+    const table = buildDetailTable([
+      { scenarioLabel: 'x', medianMs: 1, p95Ms: 1, updateMs: null, particleCount: null, frames: 10 },
+    ]);
+    expect(table).toContain('N/A | N/A |');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "ESNext",
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
+    "allowJs": true,
 
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
## 概要

性能計測を1コマンドで実行し、Markdown レポートを生成するベンチマークツールを追加します。

```bash
npm run bench                     # 現在のコードを計測
npm run bench -- --compare main   # 任意の git ref と同一条件で A/B 比較
```

vite 起動 → ヘッドフル Chrome でシナリオ別に rAF タイムスタンプ計測 → `bench-reports/` にレポート出力、まで全自動です。

## 主な機能

- **`--compare <git-ref>`**: 指定 ref を一時 worktree に展開し、同一マシン状態で交互に計測して比較表(倍率つき)を出力。再設計や性能改善の before/after 検証用
- **レポート**: 判定絵文字つきサマリ(✅60fps/⚠️/❌)、±5% の同等帯・リフレッシュレート律速検出つき比較表、詳細表(中央値/p95/renderFrame 実行時間/粒子数)、「レポートの読み方」ガイド
- シナリオ・フレーム数・ウォームアップは CLI オプションで調整可能(README 参照)

## 設計上の注意点(コメントにも記載)

- **必ずヘッドフル Chrome で計測**します。ヘッドレスや jsdom はラスタライズ経路が異なり、誤った結論が出ることを再設計の検証過程で確認済みのため
- ポートは自動割り当て(衝突回避)。Ctrl+C 時も worktree / Chrome / vite を確実に後片付け
- 統計計算・表生成は純粋関数(`scripts/bench/stats.mjs`)に分離し、ユニットテスト32本で検証

## 依存関係

- devDependencies に `puppeteer-core` を追加(Chromium はダウンロードせず、インストール済みの Chrome を使用)

## テスト

- `npm run lint`(biome の対象に scripts/ を追加)/ `npx vitest run`(76件)/ `npm run build` / `npm run depcruise` すべて green
- 実機確認: 現行コードの単独計測、`--compare main` での A/B、SIGINT 中断時のクリーンアップを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)