### PR TITLE
chore: Node.js のバージョン管理を Volta から mise に移行

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,14 +130,14 @@ npm run bench -- --scenarios default,500 --frames 60 --warmup 1000
 - Node.js >= 18.0.0
 - npm >= 9.0.0
 
-[Volta](https://volta.sh/) is a convenient tool for managing Node.js and npm versions:
+[mise](https://mise.jdx.dev/) is a convenient tool for managing Node.js versions. The project's Node.js version is pinned in `mise.toml`:
 
 ```sh
-# Install Volta
-curl https://get.volta.sh | bash
+# Install mise
+curl https://mise.run | sh
 
-# Install Node.js and npm
-volta install node@18
+# Install the pinned Node.js version (reads mise.toml)
+mise install
 ```
 
 ### Graphviz (For Dependency Visualization)

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,4 @@
+# Node.js のバージョン管理(https://mise.jdx.dev/)
+# `mise install` でこのバージョンがプロジェクトに入る
+[tools]
+node = "18.20.5"

--- a/package.json
+++ b/package.json
@@ -18,10 +18,6 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "volta": {
-    "node": "18.20.5",
-    "npm": "9.9.4"
-  },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@types/jsdom": "^21.1.7",


### PR DESCRIPTION
## 概要

Node.js のバージョン管理ツールを Volta から [mise](https://mise.jdx.dev/) に移行します。

## 変更内容

- `mise.toml` を追加(node **18.20.5** — 従来の volta ピンと同一バージョン)
- `package.json` の `volta` ブロックを削除
- README の Prerequisites を mise のセットアップ手順に更新

## 補足

- npm の個別ピン(volta では 9.9.4)は廃止し、node 18.20.5 同梱の npm 10.8.2 に委ねます(README の要件 npm >= 9.0.0 は満たします)。mise は node 同梱の npm を使う流儀のためです
- 動作確認: `mise install` で 18.20.5 が入り `mise exec -- node --version` が期待どおりであることをローカルで確認済み。node 18 でのビルド・テストは CI が検証します
- CI(actions/setup-node の 18.x 指定)はそのままです

🤖 Generated with [Claude Code](https://claude.com/claude-code)