### PR TITLE
perf: shadow* 排除・グラデーションキャッシュ・ダブルバッファ撤去で描画パスを最適化

### DIFF
--- a/src/core/renderers/DropletRenderer.ts
+++ b/src/core/renderers/DropletRenderer.ts
@@ -3,42 +3,59 @@ import type { ParticleRenderer } from './ParticleRenderer';
 const SHADOW_COLOR = '#007fff';
 const SHADOW_OFFSET_X = 1;
 const SHADOW_OFFSET_Y = 1;
-/**
- * 旧実装(atoms/H2o.ts)は shadowBlur を明示設定していなかったが、
- * 全粒子が共有する bufferCtx 上でテキスト粒子(H/H2/O)の render が設定した
- * shadowBlur = 1 が持ち越されるため、H2o は実質常に shadowBlur = 1 で
- * 描画されていた。暗黙の状態持ち越しに依存せず、実効値の 1 を明示的に設定する。
- */
-const SHADOW_BLUR = 1;
+const TWO_PI = Math.PI * 2;
 
 /**
  * 水滴(グラデーション円)描画(H2o 用)。
- * 毎フレーム createRadialGradient + arc + fill で直描きする。
+ *
+ * shadow* プロパティは使わない。Canvas 2D の shadow は fill のたびに
+ * 別レイヤーへの描画+ブラー+合成が走る高価な経路のため、
+ * 「1px ずらした影色の単色円を先に描く」疑似シャドウで置き換えている
+ * (旧実装の実効値は shadowBlur=1・オフセット(1,1) で、見た目の差は
+ * 縁 1px のごく僅かなぼかしの有無のみ)。
+ *
+ * グラデーションは座標依存のため、原点基準で 1 度だけ生成してキャッシュし、
+ * setTransform で粒子位置へ平行移動して使い回す(サイズはインスタンスごとに
+ * 固定なので、粒子の生存期間を通して 1 個で足りる)。
  *
  * スプライトキャッシュ(オフスクリーン canvas + drawImage)は実ブラウザ計測で
  * フレーム全体のラスタライズが退行したため不採用(詳細は
  * .claude/docs/redesign-plan.md §2.3)。
  */
 export class DropletRenderer implements ParticleRenderer {
+  private gradient: CanvasGradient | null = null;
+
   constructor(private readonly size: number) {} // 水滴の直径
 
   public render(ctx: CanvasRenderingContext2D, x: number, y: number): void {
-    const offset = this.size * 0.4;
-    const gx = x - offset;
-    const gy = y - offset;
-    const gr = this.size / 2 + offset;
-    const grad = ctx.createRadialGradient(gx, gy, 0, gx, gy, gr);
-    grad.addColorStop(0, 'rgba(255, 255, 255, 0.6)');
-    grad.addColorStop(1, 'rgba(0, 127, 255, 1)');
+    const r = this.size / 2;
 
+    // 疑似シャドウ: 本体を 1px ずらした影色の単色円
     ctx.beginPath();
-    ctx.arc(x, y, this.size / 2, 0, Math.PI * 2, true);
-    ctx.shadowColor = SHADOW_COLOR;
-    ctx.shadowOffsetX = SHADOW_OFFSET_X;
-    ctx.shadowOffsetY = SHADOW_OFFSET_Y;
-    ctx.shadowBlur = SHADOW_BLUR;
-    ctx.fillStyle = grad;
+    ctx.arc(x + SHADOW_OFFSET_X, y + SHADOW_OFFSET_Y, r, 0, TWO_PI, true);
+    ctx.fillStyle = SHADOW_COLOR;
     ctx.fill();
-    ctx.closePath();
+
+    // 本体(グラデーションは原点基準キャッシュ + setTransform で移動)
+    if (!this.gradient) {
+      const offset = this.size * 0.4;
+      const grad = ctx.createRadialGradient(
+        -offset,
+        -offset,
+        0,
+        -offset,
+        -offset,
+        r + offset,
+      );
+      grad.addColorStop(0, 'rgba(255, 255, 255, 0.6)');
+      grad.addColorStop(1, 'rgba(0, 127, 255, 1)');
+      this.gradient = grad;
+    }
+    ctx.setTransform(1, 0, 0, 1, x, y);
+    ctx.beginPath();
+    ctx.arc(0, 0, r, 0, TWO_PI, true);
+    ctx.fillStyle = this.gradient;
+    ctx.fill();
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
   }
 }

--- a/src/core/renderers/SubscriptTextRenderer.ts
+++ b/src/core/renderers/SubscriptTextRenderer.ts
@@ -1,7 +1,18 @@
 import type { ParticleRenderer } from './ParticleRenderer';
 
+const SHADOW_COLOR = '#888';
+const SHADOW_OFFSET_X = 1;
+const SHADOW_OFFSET_Y = 1;
+
 /**
  * 下付き文字付きテキスト描画(H2 用)。毎フレーム fillText で直描きする。
+ *
+ * shadow* プロパティは使わない。Canvas 2D の shadow は描画のたびに
+ * 別レイヤーへの描画+ブラー+合成が走る高価な経路のため、
+ * 「1px ずらした影色のテキストを先に描く」疑似シャドウで置き換えている
+ * (旧実装の実効値は shadowBlur=1・オフセット(1,1))。
+ * 描画順は旧実装と同じ「本体(影→本体)→ 下付き文字(影→本体)」で、
+ * font の切り替えが 2 回で済むようにしている。
  *
  * スプライトキャッシュ(オフスクリーン canvas + drawImage)は実ブラウザ計測で
  * フレーム全体のラスタライズが退行したため不採用(詳細は
@@ -20,17 +31,26 @@ export class SubscriptTextRenderer implements ParticleRenderer {
   public render(ctx: CanvasRenderingContext2D, x: number, y: number): void {
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
-    ctx.fillStyle = this.color;
-    ctx.shadowColor = '#888';
-    ctx.shadowOffsetX = 1;
-    ctx.shadowOffsetY = 1;
-    ctx.shadowBlur = 1;
 
-    // 本体と下付き文字を分けて描画する
+    // 本体(位置は微調整)
+    const bodyX = x - this.bodyWidth / 6;
     ctx.font = `${this.fontSize}px sans-serif`;
-    ctx.fillText(this.text, x - this.bodyWidth / 6, y); // 位置は微調整
-    // 下付き文字を描画
+    ctx.fillStyle = SHADOW_COLOR;
+    ctx.fillText(this.text, bodyX + SHADOW_OFFSET_X, y + SHADOW_OFFSET_Y);
+    ctx.fillStyle = this.color;
+    ctx.fillText(this.text, bodyX, y);
+
+    // 下付き文字(位置は微調整)
+    const subX = x + 12;
+    const subY = y + 3;
     ctx.font = `${this.subscriptFontSize}px sans-serif`;
-    ctx.fillText(this.subscript, x + 12, y + 3); // 位置は微調整
+    ctx.fillStyle = SHADOW_COLOR;
+    ctx.fillText(
+      this.subscript,
+      subX + SHADOW_OFFSET_X,
+      subY + SHADOW_OFFSET_Y,
+    );
+    ctx.fillStyle = this.color;
+    ctx.fillText(this.subscript, subX, subY);
   }
 }

--- a/src/core/renderers/TextRenderer.ts
+++ b/src/core/renderers/TextRenderer.ts
@@ -1,7 +1,16 @@
 import type { ParticleRenderer } from './ParticleRenderer';
 
+const SHADOW_COLOR = '#888';
+const SHADOW_OFFSET_X = 1;
+const SHADOW_OFFSET_Y = 1;
+
 /**
  * 影付きテキスト描画(H, O 用)。毎フレーム fillText で直描きする。
+ *
+ * shadow* プロパティは使わない。Canvas 2D の shadow は描画のたびに
+ * 別レイヤーへの描画+ブラー+合成が走る高価な経路のため、
+ * 「1px ずらした影色のテキストを先に描く」疑似シャドウで置き換えている
+ * (旧実装の実効値は shadowBlur=1・オフセット(1,1))。
  *
  * スプライトキャッシュ(オフスクリーン canvas + drawImage)は実ブラウザ計測で
  * フレーム全体のラスタライズが退行したため不採用(詳細は
@@ -17,13 +26,12 @@ export class TextRenderer implements ParticleRenderer {
   public render(ctx: CanvasRenderingContext2D, x: number, y: number): void {
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
-    ctx.fillStyle = this.color;
-    ctx.shadowColor = '#888';
-    ctx.shadowOffsetX = 1;
-    ctx.shadowOffsetY = 1;
-    ctx.shadowBlur = 1;
-
     ctx.font = `${this.fontSize}px sans-serif`;
+
+    // 疑似シャドウ → 本体の順に描く
+    ctx.fillStyle = SHADOW_COLOR;
+    ctx.fillText(this.text, x + SHADOW_OFFSET_X, y + SHADOW_OFFSET_Y);
+    ctx.fillStyle = this.color;
     ctx.fillText(this.text, x, y);
   }
 }

--- a/src/simulator/MizuSimulator.ts
+++ b/src/simulator/MizuSimulator.ts
@@ -12,8 +12,6 @@ export class MizuSimulator {
   private readonly cw: number;
   private readonly ch: number;
   private readonly ctx: CanvasRenderingContext2D;
-  private readonly bufferCanvas: HTMLCanvasElement;
-  private readonly bufferCtx: CanvasRenderingContext2D;
   /**
    * 反応に関与しうる kind の集合(Registry の読み取り専用ビュー)。
    * どのルールにも現れない kind(例: H2o)は衝突判定に渡さない。
@@ -43,16 +41,6 @@ export class MizuSimulator {
       throw new Error('Canvas context not available');
     }
     this.ctx = ctx;
-
-    // ダブルバッファリング
-    this.bufferCanvas = document.createElement('canvas');
-    this.bufferCanvas.width = this.cw;
-    this.bufferCanvas.height = this.ch;
-    const bufferCtx = this.bufferCanvas.getContext('2d');
-    if (!bufferCtx) {
-      throw new Error('Buffer canvas context not available');
-    }
-    this.bufferCtx = bufferCtx;
   }
 
   public init(hCount: number, oCount: number): void {
@@ -122,14 +110,17 @@ export class MizuSimulator {
       bucket.push(p);
     }
 
-    this.bufferCtx.fillStyle = '#fff';
-    this.bufferCtx.fillRect(0, 0, this.cw, this.ch);
+    // 画面 canvas へ直描きする。かつては手製のダブルバッファリング
+    // (オフスクリーン canvas に描いて drawImage で転写)を行っていたが、
+    // ブラウザは rAF 内の canvas 描画をもともとダブルバッファリングしており、
+    // 転写は毎フレーム全画面 1 枚分のラスタライズを追加するだけだった。
+    this.ctx.fillStyle = '#fff';
+    this.ctx.fillRect(0, 0, this.cw, this.ch);
     for (const bucket of this.renderBuckets.values()) {
       for (const p of bucket) {
-        p.render(this.bufferCtx);
+        p.render(this.ctx);
       }
     }
-    this.ctx.drawImage(this.bufferCanvas, 0, 0);
   }
 
   public count(kind: ParticleKind): number {

--- a/tests/core/renderers/renderers.test.ts
+++ b/tests/core/renderers/renderers.test.ts
@@ -12,7 +12,12 @@ const createCtx = (): CanvasRenderingContext2D => {
   return ctx;
 };
 
-type DrawMethod = 'fillText' | 'fill' | 'arc' | 'createRadialGradient';
+type DrawMethod =
+  | 'fillText'
+  | 'fill'
+  | 'arc'
+  | 'createRadialGradient'
+  | 'setTransform';
 
 /**
  * node-canvas では fillText / fill / arc 等は prototype メソッドとして
@@ -31,28 +36,29 @@ describe('TextRenderer のテスト', () => {
     expect(() => renderer.render(createCtx(), 100, 100)).not.toThrow();
   });
 
-  it('指定した色とフォントと影で描画されること', () => {
+  it('指定した色とフォントで描画され、高価な shadow* プロパティを使わないこと', () => {
     const ctx = createCtx();
     const renderer = new TextRenderer('O', '#00ff00', 28.8);
     renderer.render(ctx, 100, 100);
 
     expect(ctx.fillStyle).toBe('#00ff00');
     expect(ctx.font).toBe('28.8px sans-serif');
-    expect(ctx.shadowColor).toBe('#888888');
-    expect(ctx.shadowOffsetX).toBe(1);
-    expect(ctx.shadowOffsetY).toBe(1);
-    expect(ctx.shadowBlur).toBe(1);
+    // 疑似シャドウ(1px ずらした2度描き)方式のため shadow* は既定値のまま
+    expect(ctx.shadowBlur).toBe(0);
+    expect(ctx.shadowOffsetX).toBe(0);
+    expect(ctx.shadowOffsetY).toBe(0);
   });
 
-  it('指定した座標にテキストが描画されること', () => {
+  it('疑似シャドウ(+1px の影色)→ 本体の順にテキストが描画されること', () => {
     const ctx = createCtx();
     const fillTextSpy = spyOnProto(ctx, 'fillText');
     const renderer = new TextRenderer('H', '#ff0000', 24);
 
     renderer.render(ctx, 100, 200);
 
-    expect(fillTextSpy).toHaveBeenCalledTimes(1);
-    expect(fillTextSpy).toHaveBeenCalledWith('H', 100, 200);
+    expect(fillTextSpy).toHaveBeenCalledTimes(2);
+    expect(fillTextSpy).toHaveBeenNthCalledWith(1, 'H', 101, 201);
+    expect(fillTextSpy).toHaveBeenNthCalledWith(2, 'H', 100, 200);
   });
 });
 
@@ -71,7 +77,7 @@ describe('SubscriptTextRenderer のテスト', () => {
     expect(ctx.font).toBe('18px sans-serif');
   });
 
-  it('本体と下付き文字が旧実装どおりのオフセットで描画されること', () => {
+  it('本体・下付き文字とも疑似シャドウ→本体の順に、旧実装どおりのオフセットで描画されること', () => {
     const ctx = createCtx();
     const fillTextSpy = spyOnProto(ctx, 'fillText');
     const bodyWidth = 30;
@@ -86,16 +92,23 @@ describe('SubscriptTextRenderer のテスト', () => {
 
     renderer.render(ctx, 100, 200);
 
-    expect(fillTextSpy).toHaveBeenCalledTimes(2);
-    // 本体: x - bodyWidth / 6
+    expect(fillTextSpy).toHaveBeenCalledTimes(4);
+    // 本体: x - bodyWidth / 6(疑似シャドウは +1px)
     expect(fillTextSpy).toHaveBeenNthCalledWith(
       1,
+      'H',
+      100 - bodyWidth / 6 + 1,
+      201,
+    );
+    expect(fillTextSpy).toHaveBeenNthCalledWith(
+      2,
       'H',
       100 - bodyWidth / 6,
       200,
     );
-    // 下付き文字: x + 12, y + 3
-    expect(fillTextSpy).toHaveBeenNthCalledWith(2, '2', 112, 203);
+    // 下付き文字: x + 12, y + 3(疑似シャドウは +1px)
+    expect(fillTextSpy).toHaveBeenNthCalledWith(3, '2', 113, 204);
+    expect(fillTextSpy).toHaveBeenNthCalledWith(4, '2', 112, 203);
   });
 });
 
@@ -105,74 +118,85 @@ describe('DropletRenderer のテスト', () => {
     expect(() => renderer.render(createCtx(), 100, 100)).not.toThrow();
   });
 
-  it('影の色・オフセット・実効 shadowBlur=1 が fill 時に設定されていること', () => {
+  it('疑似シャドウ(影色の単色円)→ 本体の 2 回 fill され、shadow* プロパティを使わないこと', () => {
     const ctx = createCtx();
     const proto = Object.getPrototypeOf(ctx) as CanvasRenderingContext2D;
     const originalFill = proto.fill;
-    const captured: Array<{
-      shadowColor: string;
-      shadowBlur: number;
-      shadowOffsetX: number;
-      shadowOffsetY: number;
-    }> = [];
+    const capturedFillStyles: Array<string | CanvasGradient | CanvasPattern> =
+      [];
     const fillSpy = vi
       .spyOn(proto, 'fill')
       .mockImplementation(function (
         this: CanvasRenderingContext2D,
         ...args: Parameters<CanvasRenderingContext2D['fill']>
       ) {
-        captured.push({
-          shadowColor: this.shadowColor as string,
-          shadowBlur: this.shadowBlur,
-          shadowOffsetX: this.shadowOffsetX,
-          shadowOffsetY: this.shadowOffsetY,
-        });
+        capturedFillStyles.push(this.fillStyle);
         return originalFill.apply(this, args);
       });
 
     const renderer = new DropletRenderer(21);
     renderer.render(ctx, 100, 100);
 
-    expect(captured).toHaveLength(1);
-    expect(captured[0].shadowColor).toBe('#007fff');
-    expect(captured[0].shadowOffsetX).toBe(1);
-    expect(captured[0].shadowOffsetY).toBe(1);
-    // 旧実装では共有 bufferCtx にテキスト粒子の shadowBlur=1 が持ち越されて描画されて
-    // いた(実効値 1)。暗黙の持ち越しに依存せず DropletRenderer が明示的に 1 を
-    // 設定する(見た目の維持)
-    expect(captured[0].shadowBlur).toBe(1);
+    expect(capturedFillStyles).toHaveLength(2);
+    // 1 回目: 疑似シャドウの単色、2 回目: 本体のグラデーション
+    expect(capturedFillStyles[0]).toBe('#007fff');
+    expect(typeof capturedFillStyles[1]).toBe('object');
+    // 疑似シャドウ方式のため shadow* は既定値のまま
+    expect(ctx.shadowBlur).toBe(0);
+    expect(ctx.shadowOffsetX).toBe(0);
+    expect(ctx.shadowOffsetY).toBe(0);
 
     fillSpy.mockRestore();
   });
 
-  it('グラデーションが粒子位置からの相対オフセットで生成されること', () => {
+  it('グラデーションが原点基準で生成され、setTransform で粒子位置へ移動されること', () => {
     const ctx = createCtx();
     const gradientSpy = spyOnProto(ctx, 'createRadialGradient');
+    const transformSpy = spyOnProto(ctx, 'setTransform');
     const size = 20;
     const renderer = new DropletRenderer(size);
 
     renderer.render(ctx, 100, 100);
 
-    // gx = x - size*0.4, gy = y - size*0.4, 半径 0 → size/2 + size*0.4
+    // 原点基準: 中心 (-offset, -offset)、半径 0 → size/2 + offset
     const offset = size * 0.4;
     expect(gradientSpy).toHaveBeenCalledWith(
-      100 - offset,
-      100 - offset,
+      -offset,
+      -offset,
       0,
-      100 - offset,
-      100 - offset,
+      -offset,
+      -offset,
       size / 2 + offset,
     );
+    // 粒子位置へ平行移動し、描画後に単位行列へ戻す
+    expect(transformSpy).toHaveBeenNthCalledWith(1, 1, 0, 0, 1, 100, 100);
+    expect(transformSpy).toHaveBeenNthCalledWith(2, 1, 0, 0, 1, 0, 0);
   });
 
-  it('円弧(arc)が粒子位置を中心に半径 size/2 で描かれること', () => {
+  it('グラデーションはインスタンスごとに 1 回だけ生成されキャッシュされること', () => {
+    const ctx = createCtx();
+    const gradientSpy = spyOnProto(ctx, 'createRadialGradient');
+    const renderer = new DropletRenderer(24);
+
+    renderer.render(ctx, 10, 10);
+    renderer.render(ctx, 20, 20);
+    renderer.render(ctx, 30, 30);
+
+    expect(gradientSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('疑似シャドウは +1px、本体は移動後の原点を中心に半径 size/2 で描かれること', () => {
     const ctx = createCtx();
     const arcSpy = spyOnProto(ctx, 'arc');
     const renderer = new DropletRenderer(24);
 
     renderer.render(ctx, 50, 60);
 
-    expect(arcSpy).toHaveBeenCalledWith(50, 60, 12, 0, Math.PI * 2, true);
+    expect(arcSpy).toHaveBeenCalledTimes(2);
+    // 疑似シャドウ: (x+1, y+1)
+    expect(arcSpy).toHaveBeenNthCalledWith(1, 51, 61, 12, 0, Math.PI * 2, true);
+    // 本体: setTransform(…, x, y) 後の原点
+    expect(arcSpy).toHaveBeenNthCalledWith(2, 0, 0, 12, 0, Math.PI * 2, true);
   });
 
   it('直描き方式のため render でオフスクリーン canvas を生成しないこと', () => {

--- a/tests/simulator/MizuSimulator.perf.test.ts
+++ b/tests/simulator/MizuSimulator.perf.test.ts
@@ -48,6 +48,7 @@ describe('MizuSimulator の性能回帰チェック(粗い上限テスト)', () 
       arc: () => {},
       fill: () => {},
       createRadialGradient: () => ({ addColorStop: () => {} }),
+      setTransform: () => {},
       measureText: (text: string) => ({ width: 15 * text.length }),
     };
     const canvasProto = Object.getPrototypeOf(


### PR DESCRIPTION
## 概要

描画パスの 3 つの最適化で、高負荷シナリオ(h=1000, o=1000)の wall フレーム時間を **1.3x 高速化**し、中負荷(h=500, o=500)の renderFrame 実行時間(JS)を **55% 削減**する。

1. **shadow* プロパティの排除**(全レンダラー): Canvas 2D の shadow は描画のたびに別レイヤーへの描画+ブラー+合成が走る高価な経路のため、「1px ずらした影色の図形を先に描く」疑似シャドウの 2 度描きに置換
2. **水滴グラデーションのキャッシュ**(`DropletRenderer`): 従来は水滴ごと・毎フレーム `createRadialGradient` していたものを、原点基準で初回のみ生成し `setTransform` で粒子位置へ移動して再利用
3. **手製ダブルバッファリングの撤去**(`MizuSimulator`): ブラウザは rAF 内の canvas 描画をもともとダブルバッファリングしており、オフスクリーン canvas への描画 + `drawImage` 転写は毎フレーム全画面 1 枚分のラスタライズ追加+同期フラッシュの強制になっていた

## 計測結果(bench ツールによる main との同一セッション A/B)

計測環境: ローカル Chrome 149 / macOS (arm64) / 1280x800 / warmup 3000ms。`npm run bench -- --compare main`

| シナリオ | main | 本ブランチ | 判定 |
| --- | --- | --- | --- |
| デフォルト (h=30, o=50) | 16.7ms | 16.7ms | 60fps 維持(vsync 律速) |
| h=500, o=500 wall 平均 | 24.2〜25.2ms | 24.4〜26.9ms | ≒同等(4 回計測、差は H2o 滞留数の乱数ゆらぎに埋没) |
| h=500, o=500 renderFrame (JS) | 19.9〜25.6ms | **9.3〜12.5ms** | **約 -55%(全計測で一貫)** |
| h=1000, o=1000 wall 平均 | 142.8〜144.2ms | **113.4〜114.3ms** | **1.2〜1.3x faster(3 回すべてで再現)** |

補足:

- h=1000(粒子約 5 万)の高速化は shadow 排除によるラスタライズ削減が支配的
- h=500 の wall 時間は vsync 境界(16.7ms)に律速されて差が出ないが、JS 時間の半減(主にダブルバッファ撤去による `drawImage` 同期フラッシュの解消)でメインスレッドの余裕が大きく増えている
- redesign-plan.md §2.3 の教訓どおり、全変更を実ブラウザの rAF 計測で A/B 済み

## 見た目への影響

新旧実装を同一座標で描画した比較ページで確認済み。実寸では区別がつかず、4 倍拡大でテキスト粒子の影の縁 1px のぼかしの有無が分かる程度(水滴は影がほぼ本体に隠れるため拡大でも差はほぼ視認不可)。

## テスト

- 既存テストを疑似シャドウ・グラデーションキャッシュの検証に更新(172 件パス)
- lint / format クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)